### PR TITLE
Added traffic prediction

### DIFF
--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -10,7 +10,8 @@ import numpy as np
 
 
 class SimulatorParams:
-    def __init__(self, network, ing_nodes, sfc_list, sf_list, config, metrics, schedule=None, sf_placement=None):
+    def __init__(self, network, ing_nodes, sfc_list, sf_list, config, metrics, prediction,
+                 schedule=None, sf_placement=None):
         # NetworkX network object: DiGraph
         self.network = network
         # Ingress nodes of the network (nodes at which flows arrive): list
@@ -23,6 +24,9 @@ class SimulatorParams:
         self.use_trace = False
         if 'trace_path' in config:
             self.use_trace = True
+
+        self.prediction = prediction  # bool
+        self.predicted_inter_arr_mean = {node_id: config['inter_arrival_mean'] for node_id in self.network.nodes}
 
         if schedule is None:
             schedule = {}
@@ -96,6 +100,9 @@ class SimulatorParams:
 
     def update_single_inter_arr_mean(self, new_mean):
         self.inter_arr_mean = {node_id: new_mean for node_id in self.network.nodes}
+
+    def update_single_predicted_inter_arr_mean(self, new_mean):
+        self.predicted_inter_arr_mean = {node_id: new_mean for node_id in self.network.nodes}
 
     # string representation for logging
     def __str__(self):

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 class SimulatorParams:
-    def __init__(self, network, ing_nodes, sfc_list, sf_list, config, metrics, prediction,
+    def __init__(self, network, ing_nodes, sfc_list, sf_list, config, metrics, prediction=False,
                  schedule=None, sf_placement=None):
         # NetworkX network object: DiGraph
         self.network = network

--- a/src/coordsim/trace_processor/trace_processor.py
+++ b/src/coordsim/trace_processor/trace_processor.py
@@ -1,6 +1,7 @@
 from coordsim.simulation.simulatorparams import SimulatorParams
 from coordsim.simulation.flowsimulator import FlowSimulator
 from simpy import Environment
+import numpy as np
 import logging
 log = logging.getLogger(__name__)
 
@@ -14,9 +15,12 @@ class TraceProcessor():
         self.params = params
         self.env = env
         self.trace_index = 0
+        self.prediction_trace_index = 0
         self.trace = trace
         self.simulator = simulator
         self.env.process(self.process_trace())
+        if self.params.prediction:
+            self.env.process(self.prediction())
 
     def process_trace(self):
         """
@@ -37,6 +41,9 @@ class TraceProcessor():
                 inter_arrival_mean = float(inter_arrival_mean)
                 old_mean = self.params.inter_arr_mean[node_id]
                 self.params.inter_arr_mean[node_id] = inter_arrival_mean
+                if 'cap' in self.trace[self.trace_index]:
+                    cap = self.trace[self.trace_index]["cap"]
+                    self.params.network.nodes[node_id]["cap"] = float(cap)
                 if old_mean is None:
                     self.env.process(self.simulator.generate_flow(node_id))
         else:
@@ -45,3 +52,34 @@ class TraceProcessor():
         if self.trace_index < len(self.trace)-1:
             self.trace_index += 1
             self.env.process(self.process_trace())
+
+    def prediction(self):
+        """
+        Check the trace file and update the simulator param 'predicted_inter_arr_mean'
+        one run duration before the trace module updates the actual mean
+
+        """
+        # -1 here because the prediction always was always scheduled after the SimulatorState code was executed
+        # Must check this further to see if there is a way to change orde of events in SimPy
+        timeout = float(self.trace[self.prediction_trace_index]['time']) - self.env.now - self.params.run_duration - 1
+        # Cap to make sure we don't have timeout less 0, otherwise raises exception in SimPy
+        self.prediction_timeout = np.clip(timeout, 0, None)
+        inter_arrival_mean = self.trace[self.prediction_trace_index]['inter_arrival_mean']
+        yield self.env.timeout(self.prediction_timeout)
+        log.debug(f"Predicted inter arrival mean changed to {inter_arrival_mean} at {self.env.now}")
+        if 'node' in self.trace[self.prediction_trace_index]:
+            node_id = self.trace[self.prediction_trace_index]['node']
+            if inter_arrival_mean == 'None':
+                self.params.predicted_inter_arr_mean[node_id] = None
+            else:
+                inter_arrival_mean = float(inter_arrival_mean)
+                old_mean = self.params.inter_arr_mean[node_id]
+                self.params.predicted_inter_arr_mean[node_id] = inter_arrival_mean
+                if old_mean is None:
+                    self.env.process(self.simulator.generate_flow(node_id))
+        else:
+            inter_arrival_mean = float(inter_arrival_mean)
+            self.params.update_single_predicted_inter_arr_mean(inter_arrival_mean)
+        if self.prediction_trace_index < len(self.trace)-1:
+            self.prediction_trace_index += 1
+            self.env.process(self.prediction())

--- a/src/coordsim/traffic_predictor/traffic_predictor.py
+++ b/src/coordsim/traffic_predictor/traffic_predictor.py
@@ -1,0 +1,46 @@
+from coordsim.simulation.simulatorparams import SimulatorParams
+from collections import defaultdict
+from math import ceil
+import numpy as np
+import logging
+log = logging.getLogger(__name__)
+
+
+class TrafficPredictor():
+    """
+    Traffic Predictor class
+    Updates traffic dict in metrics module to show upcoming traffic at ingress node.
+    """
+
+    def __init__(self, params: SimulatorParams):
+        self.params = params
+
+    def predict_traffic(self):
+        """
+        Predicts the traffic at ingress nodes based on the current inter_arrival_mean
+        Currently only supports deterministic traffic and single SFC
+        """
+        # reset total requested traffic
+        self.params.metrics.metrics['run_total_requested_traffic'] = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(float)))
+
+        # Add predicted data rate to ingress SFCs
+        for node in self.params.ing_nodes:
+            # get node_id
+            node_id = node[0]
+            # get sfc_id - currently assumes one SFC
+            sfc_ids = self.params.sfc_list.keys()
+            sfc_ids = [*sfc_ids]  # New unpacking trick in python 3.5+
+            sfc = sfc_ids[0]
+            ingress_sf = self.params.sfc_list[sfc][0]
+
+            # Calculate flow count for each ingress node
+            flow_dr = 0.0
+            number_of_flows = self.params.run_duration / self.params.predicted_inter_arr_mean[node_id]
+
+            # Predict data rate for expected number of flows
+            for _ in range(ceil(number_of_flows)):
+                flow_dr += np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
+
+            # Update ingress traffic in metrics module
+            self.params.metrics.metrics['run_total_requested_traffic'][node_id][sfc][ingress_sf] = flow_dr

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -39,7 +39,7 @@ class Simulator(SimulatorInterface):
         if 'future_traffic' in self.config and self.config['future_traffic']:
             self.prediction = True
         self.params = SimulatorParams(self.network, self.ing_nodes, self.sfc_list, self.sf_list, self.config,
-                                      self.metrics, self.prediction)
+                                      self.metrics, prediction=self.prediction)
         if self.prediction:
             self.predictor = TrafficPredictor(self.params)
         self.episode = 0

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -39,7 +39,7 @@ class TestFlowSimulator(TestCase):
 
         # Initialize Simulator and SimulatoParams objects
         self.simulator_params = SimulatorParams(network, ing_nodes, sfc_list, sf_list, config, self.metrics,
-                                                prediction=False, sf_placement=sf_placement, schedule=schedule)
+                                                sf_placement=sf_placement, schedule=schedule)
         self.flow_simulator = FlowSimulator(self.env, self.simulator_params)
         self.flow_simulator.start()
         self.env.run(until=SIMULATION_DURATION)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -39,7 +39,7 @@ class TestFlowSimulator(TestCase):
 
         # Initialize Simulator and SimulatoParams objects
         self.simulator_params = SimulatorParams(network, ing_nodes, sfc_list, sf_list, config, self.metrics,
-                                                sf_placement=sf_placement, schedule=schedule)
+                                                prediction=False, sf_placement=sf_placement, schedule=schedule)
         self.flow_simulator = FlowSimulator(self.env, self.simulator_params)
         self.flow_simulator.start()
         self.env.run(until=SIMULATION_DURATION)


### PR DESCRIPTION
I have added a traffic prediction module. 

This is a very rough initial implementation just to test the concept. 
Due to the way SimPy schedules events, I had to add schedule the traffic prediction update 1 timestep before the run ends to make sure it is updated. The "prediction" code apparently is scheduled to run after the state is passed to the agent. 

I will add a sample config file for the prediction along with the trace in the RL repo.