### PR TITLE
Adding random traffic prediction 

### DIFF
--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -37,56 +37,48 @@ class FlowSimulator:
             node_id = node[0]
             self.env.process(self.generate_flow(node_id))
 
-    def gen_flow_params(self, node_id, index):
-        """
-        Calculate flow parameters based on whether prediction is enabled or not
-        """
-        if self.params.arrival_list is not None:
-            flow_dr = self.params.flow_drs[node_id][index]
-            flow_size = self.params.flow_sizes[node_id][index]
-            inter_arr_time = self.params.arrival_list[node_id][index]
-        else:
-            # set normally distributed flow data rate
-            flow_dr = np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
-
-            # set deterministic or random flow arrival times and flow sizes according to config
-            if self.params.deterministic_arrival:
-                inter_arr_time = self.params.inter_arr_mean[node_id]
-            else:
-                # Poisson arrival -> exponential distributed inter-arrival time
-                inter_arr_time = random.expovariate(lambd=1.0/self.params.inter_arr_mean[node_id])
-
-            if self.params.deterministic_size:
-                flow_size = self.params.flow_size_shape
-            else:
-                # heavy-tail flow size
-                flow_size = np.random.pareto(self.params.flow_size_shape) + 1
-
-        # Skip flows with negative flow_dr or flow_size values
-        if flow_dr <= 0.00 or flow_size <= 0.00:
-            flow_dr = False
-            flow_size = False
-
-        return inter_arr_time, flow_size, flow_dr
-
     def generate_flow(self, node_id):
         """
         Generate flows at the ingress nodes.
         """
         inter_arrival_index = 0
         # Change loop condition based on whether prediction is on or not
-        if self.params.arrival_list is not None:
-            loop_condition = inter_arrival_index < len(self.params.arrival_list)
+        if self.params.prediction:
+            loop_condition = inter_arrival_index < len(self.params.arrival_list[node_id])
         else:
             loop_condition = self.params.inter_arr_mean[node_id] is not None
 
         while loop_condition:
             self.total_flow_count += 1
-            inter_arr_time, flow_size, flow_dr = self.gen_flow_params(node_id, inter_arrival_index)
+            if self.params.prediction:
+                flow_dr = self.params.flow_drs[node_id][inter_arrival_index]
+                flow_size = self.params.flow_sizes[node_id][inter_arrival_index]
+                inter_arr_time = self.params.arrival_list[node_id][inter_arrival_index]
+                inter_arrival_index += 1
+                # Update loop condition again because it doesnt automatically update
+                loop_condition = inter_arrival_index < len(self.params.arrival_list[node_id])
+                # If we arrived at end of arrival list, prepare for new one
+                if not loop_condition:
+                    inter_arrival_index = 0
+                    loop_condition = True
+            else:
+                # set normally distributed flow data rate
+                flow_dr = np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
+                # set deterministic or random flow arrival times and flow sizes according to config
+                if self.params.deterministic_arrival:
+                    inter_arr_time = self.params.inter_arr_mean[node_id]
+                else:
+                    # Poisson arrival -> exponential distributed inter-arrival time
+                    inter_arr_time = random.expovariate(lambd=1.0/self.params.inter_arr_mean[node_id])
+                if self.params.deterministic_size:
+                    flow_size = self.params.flow_size_shape
+                else:
+                    # heavy-tail flow size
+                    flow_size = np.random.pareto(self.params.flow_size_shape) + 1
 
-            # Skip flows with negative flow_dr or flow_size values
-            if not flow_dr or not flow_size:
-                continue
+                # Skip flows with negative flow_dr or flow_size values
+                if flow_dr <= 0.00 or flow_size <= 0.00:
+                    continue
 
             # Assign a random SFC to the flow
             flow_sfc = np.random.choice([sfc for sfc in self.params.sfc_list.keys()])
@@ -104,7 +96,6 @@ class FlowSimulator:
             # Generate flows and schedule them at ingress node
             self.env.process(self.init_flow(flow))
 
-            inter_arrival_index += 1
             yield self.env.timeout(inter_arr_time)
 
     def init_flow(self, flow):

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -86,6 +86,8 @@ class SimulatorParams:
                 self.current_state = self.init_state
             state_inter_arr_mean = self.states[self.current_state]['inter_arr_mean']
             self.update_single_inter_arr_mean(state_inter_arr_mean)
+            if self.prediction:
+                self.update_single_predicted_inter_arr_mean(state_inter_arr_mean)
         else:
             inter_arr_mean = config['inter_arrival_mean']
             self.update_single_inter_arr_mean(inter_arr_mean)
@@ -103,6 +105,8 @@ class SimulatorParams:
                 self.current_state = state_names[0]
         state_inter_arr_mean = self.states[self.current_state]['inter_arr_mean']
         self.update_single_inter_arr_mean(state_inter_arr_mean)
+        if self.prediction:
+            self.update_single_predicted_inter_arr_mean(state_inter_arr_mean)
 
     def update_single_inter_arr_mean(self, new_mean):
         self.inter_arr_mean = {node_id: new_mean for node_id in self.network.nodes}

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -12,6 +12,10 @@ import numpy as np
 class SimulatorParams:
     def __init__(self, network, ing_nodes, eg_nodes, sfc_list, sf_list, config, metrics, prediction=False,
                  schedule=None, sf_placement=None):
+        # Arrival DR lists if traffic prediction is enabled
+        self.arrival_list = None
+        self.flow_drs = None
+        self.flow_sizes = None
         # NetworkX network object: DiGraph
         self.network = network
         # Ingress nodes of the network (nodes at which flows arrive): list

--- a/src/coordsim/traffic_predictor/traffic_predictor.py
+++ b/src/coordsim/traffic_predictor/traffic_predictor.py
@@ -1,6 +1,5 @@
 from coordsim.simulation.simulatorparams import SimulatorParams
 from collections import defaultdict
-from math import ceil
 import numpy as np
 import random
 import logging
@@ -15,14 +14,19 @@ class TrafficPredictor():
 
     def __init__(self, params: SimulatorParams):
         self.params = params
+        # init dicts
         self.flow_drs = {}
         self.flow_sizes = {}
         self.arrival_list = {}
+        for node in self.params.ing_nodes:
+            node_id = node[0]
+            self.flow_drs[node_id] = []
+            self.flow_sizes[node_id] = []
+            self.arrival_list[node_id] = []
 
     def gen_flow_lists(self):
         """
-        Calculates the upcoming traffic at ingress nodes based on the current inter_arrival_mean
-        Currently supports single SFC
+        Generate flow arrival lists for the simulator based on 'predicted' inter_arr_mean
         """
         # reset total requested traffic
         self.params.metrics.metrics['run_total_requested_traffic'] = defaultdict(
@@ -34,11 +38,7 @@ class TrafficPredictor():
             node_id = node[0]
 
             inter_arr_mean = None
-            flow_dr = np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
 
-            # if self.params.deterministic_arrival:
-            #     # inter_arr_mean = self.params.predicted_inter_arr_mean[node_id]
-            # else:
             inter_arr_times = []
             # Poisson arrival -> exponential distributed inter-arrival time
             while sum(inter_arr_times) <= self.params.run_duration:
@@ -47,20 +47,12 @@ class TrafficPredictor():
                 else:
                     inter_arr_mean = random.expovariate(lambd=1.0/self.params.predicted_inter_arr_mean[node_id])
                 inter_arr_times.append(inter_arr_mean)
-                # inter_arr_mean = np.mean(inter_arr_times)
-            # Calculate flow count for each ingress node
-            flow_dr = 0.0
-            # number_of_flows = self.params.run_duration / inter_arr_mean
-
-            # Predict data rate for expected number of flows
-            for _ in inter_arr_times:
                 if self.params.deterministic_size:
                     self.flow_sizes[node_id].append(self.params.flow_size_shape)
                 else:
                     # heavy-tail flow size
                     self.flow_sizes[node_id].append(np.random.pareto(self.params.flow_size_shape) + 1)
-                self.flow_
-                flow_dr += np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
+                self.flow_drs[node_id].append(np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev))
 
             # Update ingress traffic in metrics module
             self.params.arrival_list = inter_arr_times
@@ -75,6 +67,14 @@ class TrafficPredictor():
             sfc_ids = self.params.sfc_list.keys()
             sfc_ids = [*sfc_ids]  # New unpacking trick in python 3.5+
             sfc = sfc_ids[0]
-            ingress_sf = self.params.sfc_list[sfc][0] 
+            ingress_sf = self.params.sfc_list[sfc][0]
             flow_dr = sum(self.flow_drs[node_id])
             self.params.metrics.metrics['run_total_requested_traffic'][node_id][sfc][ingress_sf] = flow_dr
+
+    def predict_traffic(self):
+        """
+        Calculates the upcoming traffic at ingress nodes based on the current inter_arrival_mean
+        Currently supports single SFC
+        """
+        self.gen_flow_lists()
+        self.update_metrics

--- a/src/coordsim/traffic_predictor/traffic_predictor.py
+++ b/src/coordsim/traffic_predictor/traffic_predictor.py
@@ -77,4 +77,4 @@ class TrafficPredictor():
         Currently supports single SFC
         """
         self.gen_flow_lists()
-        self.update_metrics
+        self.update_metrics()

--- a/src/coordsim/traffic_predictor/traffic_predictor.py
+++ b/src/coordsim/traffic_predictor/traffic_predictor.py
@@ -15,8 +15,11 @@ class TrafficPredictor():
 
     def __init__(self, params: SimulatorParams):
         self.params = params
+        self.flow_drs = {}
+        self.flow_sizes = {}
+        self.arrival_list = {}
 
-    def predict_traffic(self):
+    def gen_flow_lists(self):
         """
         Calculates the upcoming traffic at ingress nodes based on the current inter_arrival_mean
         Currently supports single SFC
@@ -29,33 +32,49 @@ class TrafficPredictor():
         for node in self.params.ing_nodes:
             # get node_id
             node_id = node[0]
+
+            inter_arr_mean = None
+            flow_dr = np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
+
+            # if self.params.deterministic_arrival:
+            #     # inter_arr_mean = self.params.predicted_inter_arr_mean[node_id]
+            # else:
+            inter_arr_times = []
+            # Poisson arrival -> exponential distributed inter-arrival time
+            while sum(inter_arr_times) <= self.params.run_duration:
+                if self.params.deterministic_arrival:
+                    inter_arr_mean = self.params.predicted_inter_arr_mean[node_id]
+                else:
+                    inter_arr_mean = random.expovariate(lambd=1.0/self.params.predicted_inter_arr_mean[node_id])
+                inter_arr_times.append(inter_arr_mean)
+                # inter_arr_mean = np.mean(inter_arr_times)
+            # Calculate flow count for each ingress node
+            flow_dr = 0.0
+            # number_of_flows = self.params.run_duration / inter_arr_mean
+
+            # Predict data rate for expected number of flows
+            for _ in inter_arr_times:
+                if self.params.deterministic_size:
+                    self.flow_sizes[node_id].append(self.params.flow_size_shape)
+                else:
+                    # heavy-tail flow size
+                    self.flow_sizes[node_id].append(np.random.pareto(self.params.flow_size_shape) + 1)
+                self.flow_
+                flow_dr += np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
+
+            # Update ingress traffic in metrics module
+            self.params.arrival_list = inter_arr_times
+            self.params.flow_drs = self.flow_drs
+            self.params.flow_sizes = self.flow_sizes
+
+    def update_metrics(self):
+        for node in self.params.ing_nodes:
+            # get node_id
+            node_id = node[0]
             # get sfc_id - currently assumes one SFC
             sfc_ids = self.params.sfc_list.keys()
             sfc_ids = [*sfc_ids]  # New unpacking trick in python 3.5+
             sfc = sfc_ids[0]
-            ingress_sf = self.params.sfc_list[sfc][0]
-
-            inter_arr_mean = None
-            if self.params.deterministic_arrival:
-                inter_arr_mean = self.params.predicted_inter_arr_mean[node_id]
-            else:
-                inter_arr_times = []
-                # Poisson arrival -> exponential distributed inter-arrival time
-                for _ in range(self.params.run_duration):
-                    inter_arr_times.append(random.expovariate(lambd=1.0/self.params.predicted_inter_arr_mean[node_id]))
-                    # If the duration of the inter_arr_times reaches the run duration, assume enough flows generated
-                    # for a run
-                    # This is to simulate waiting before generating another flow
-                    if sum(inter_arr_times) >= self.params.run_duration:
-                        break
-                inter_arr_mean = np.mean(inter_arr_times)
-            # Calculate flow count for each ingress node
-            flow_dr = 0.0
-            number_of_flows = self.params.run_duration / inter_arr_mean
-
-            # Predict data rate for expected number of flows
-            for _ in range(ceil(number_of_flows)):
-                flow_dr += np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
-
-            # Update ingress traffic in metrics module
+            ingress_sf = self.params.sfc_list[sfc][0] 
+            flow_dr = sum(self.flow_drs[node_id])
             self.params.metrics.metrics['run_total_requested_traffic'][node_id][sfc][ingress_sf] = flow_dr


### PR DESCRIPTION
This is currently a draft. 
I am facing the following issues: 
- Random index-out-of-range exceptions when iterating over flow_arrival list
- Figuring out how and when to stop at the last flow being generated and wait for new run
 - Sometimes `sum(arrival_list)` can be more than run_duration, so I limited it to be less or equal, which sometimes results in it being about 50-60 (way far from 100 run duration). 

Am I missing something here? I have tested this when it's not throwing exceptions and the prediction part is 100% accurate. 