### PR TITLE
Poission traffic prediction

### DIFF
--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -3,7 +3,7 @@
 # all parameters are required, defaults are in comments
 
 inter_arrival_mean: 10.0           # default: 10.0
-deterministic_arrival: True        # default: True
+deterministic_arrival: False        # default: True
 flow_dr_mean: 1.0                  # default: 1.0
 flow_dr_stdev: 0.0                 # default: 0.0
 flow_size_shape: 0.001             # default: 0.001 (for deterministic!)
@@ -21,7 +21,7 @@ run_duration: 100                  # default: 100
 
 # States (two state markov arrival)
 # Optional param: states: True | False 
-use_states: True
+use_states: False
 init_state: state_1
 
 states:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 requirements = [
-    'simpy',
+    'simpy>=4.0.1',
     'networkx',
     'geopy',
     'pyyaml>=5.1',

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -52,11 +52,15 @@ class FlowSimulator:
                 inter_arr_time = self.params.inter_arr_mean[node_id]
             else:
                 # Poisson arrival -> exponential distributed inter-arrival time
-                # inter_arr_time = random.expovariate(lambd=1.0/self.params.inter_arr_mean[node_id])
-
+                # keep this for backward compatibility
+                # when running the simulator without the sim interface, ie, without calling init,
+                # the flow lists are not generated
+                if self.params.flow_list_idx is None:
+                    inter_arr_time = random.expovariate(lambd=1.0/self.params.inter_arr_mean[node_id])
                 # use generated list of flow arrivals
-                # TODO: extend to also retrieve size and dr
-                inter_arr_time = self.params.get_next_flow_data(node_id)
+                else:
+                    # TODO: extend to also retrieve size and dr
+                    inter_arr_time = self.params.get_next_flow_data(node_id)
 
             if self.params.deterministic_size:
                 flow_size = self.params.flow_size_shape

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -51,11 +51,11 @@ class FlowSimulator:
             if self.params.deterministic_arrival:
                 inter_arr_time = self.params.inter_arr_mean[node_id]
             else:
-                # Poisson arrival -> exponential distributed inter-arrival time
                 # keep this for backward compatibility
                 # when running the simulator without the sim interface, ie, without calling init,
                 # the flow lists are not generated
                 if self.params.flow_list_idx is None:
+                    # Poisson arrival -> exponential distributed inter-arrival time
                     inter_arr_time = random.expovariate(lambd=1.0/self.params.inter_arr_mean[node_id])
                 # use generated list of flow arrivals
                 else:

--- a/src/coordsim/simulation/flowsimulator.py
+++ b/src/coordsim/simulation/flowsimulator.py
@@ -103,7 +103,7 @@ class FlowSimulator:
             log.info(f"Requested SFC was not found. Dropping flow {flow.flow_id}")
             # Update metrics for the dropped flow
             self.params.metrics.dropped_flow(flow)
-            self.env.exit()
+            return
 
     def pass_flow(self, flow, sfc):
         """
@@ -152,12 +152,12 @@ class FlowSimulator:
                             f'Dropping flow!')
                 log.warning(ex)
                 self.params.metrics.dropped_flow(flow)
-                self.env.exit()
+                return
         else:
             # Scheduling rule does not exist: drop flow
             log.warning(f'Flow {flow.flow_id}: Scheduling rule not found at {flow.current_node_id}. Dropping flow!')
             self.params.metrics.dropped_flow(flow)
-            self.env.exit()
+            return
 
     def forward_flow(self, flow, next_node):
         """
@@ -299,11 +299,11 @@ class FlowSimulator:
                 log.info(f"Not enough capacity for flow {flow.flow_id} at node {flow.current_node_id}. Dropping flow.")
                 # Update metrics for the dropped flow
                 self.params.metrics.dropped_flow(flow)
-                self.env.exit()
+                return
         else:
             log.info(f"SF {sf} was not found at {current_node_id}. Dropping flow {flow.flow_id}")
             self.params.metrics.dropped_flow(flow)
-            self.env.exit()
+            return
 
     def depart_flow(self, flow, remove_active_flow=True):
         """

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -18,13 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 class Simulator(SimulatorInterface):
-    def __init__(self,  network_file, service_functions_file, config_file, resource_functions_path="",
-                 test_mode=False, test_dir=None):
-        # SimulatorInterface.__init__(self, test_mode=test_mode)
+    def __init__(self, network_file, service_functions_file, config_file, resource_functions_path="", test_mode=False,
+                 test_dir=None):
+        super().__init__(test_mode)
         # Number of time the simulator has run. Necessary to correctly calculate env run time of apply function
         self.run_times = int(1)
         self.network_file = network_file
-        self.test_mode = test_mode
         self.test_dir = test_dir
         # Create CSV writer
         self.writer = ResultWriter(self.test_mode, self.test_dir)
@@ -84,6 +83,9 @@ class Simulator(SimulatorInterface):
         self.seed = seed
         random.seed(self.seed)
         numpy.random.seed(self.seed)
+
+        # TODO: new --> generate flow arrival
+        self.params.generate_flow_lists()
 
         # Instantiate a simulator object, pass the environment and params
         self.simulator = FlowSimulator(self.env, self.params)
@@ -234,3 +236,17 @@ class Simulator(SimulatorInterface):
     def get_active_ingress_nodes(self):
         """Return names of all ingress nodes that are currently active, ie, produce flows."""
         return [ing[0] for ing in self.ing_nodes if self.params.inter_arr_mean[ing[0]] is not None]
+
+
+# for debugging
+if __name__ == "__main__":
+    # run from project root for file paths to work
+    network_file = 'params/networks/triangle.graphml'
+    service_file = 'params/services/abc.yaml'
+    config_file = 'params/config/sim_config.yaml'
+
+    sim = Simulator(network_file, service_file, config_file)
+    state = sim.init(seed=1234)
+    dummy_action = SimulatorAction(placement={}, scheduling={})
+    # FIXME: this currently breaks - negative flow counter? should be possible to have an empty action and just drop all flows!
+    state = sim.apply(dummy_action)

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -248,5 +248,6 @@ if __name__ == "__main__":
     sim = Simulator(network_file, service_file, config_file)
     state = sim.init(seed=1234)
     dummy_action = SimulatorAction(placement={}, scheduling={})
-    # FIXME: this currently breaks - negative flow counter? should be possible to have an empty action and just drop all flows!
+    # FIXME: this currently breaks - negative flow counter?
+    #  should be possible to have an empty action and just drop all flows!
     state = sim.apply(dummy_action)


### PR DESCRIPTION
Started my idea of implementing it (as an alternative to https://github.com/RealVNF/coord-sim/pull/142):

* Generate full list of inter-arrival times for each ingress at the beginning of the run
* Keep generation of these lists (up front) and generation of flows (inside the simulator workflow) separate
* Helper functions to generate lists and retrieve next flow data: Keep it simple
* Should be easy to use generated list for predictions

Remaining todos:

* Generate flow size and data rate and use them
* Simulator fix: Why does an empty action not work?
* Maybe later: Generate lists even in deterministic traffic and MMPP traffic case. Then the flow generation function no longer has to distinguish
* See new TODOs and FIXMEs in code