### PR TITLE
Added configurable schedule recording

### DIFF
--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -3,7 +3,7 @@
 # all parameters are required, defaults are in comments
 
 inter_arrival_mean: 10.0           # default: 10.0
-deterministic_arrival: False        # default: True
+deterministic_arrival: True        # default: True
 flow_dr_mean: 1.0                  # default: 1.0
 flow_dr_stdev: 0.0                 # default: 0.0
 flow_size_shape: 0.001             # default: 0.001 (for deterministic!)
@@ -18,6 +18,8 @@ run_duration: 100                  # default: 100
 # Until values start in the trace file, the defaults from this file are used
 # trace_path: params/traces/default_trace.csv
 
+# Optional: Write Scheduling results
+write_schedule: True
 
 # States (two state markov arrival)
 # Optional param: states: True | False 

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -25,8 +25,6 @@ class Simulator(SimulatorInterface):
         self.run_times = int(1)
         self.network_file = network_file
         self.test_dir = test_dir
-        # Create CSV writer
-        self.writer = ResultWriter(self.test_mode, self.test_dir)
         # init network, sfc, sf, and config files
         self.network, self.ing_nodes, self.eg_nodes = reader.read_network(self.network_file)
         self.sfc_list = reader.get_sfc(service_functions_file)
@@ -46,6 +44,11 @@ class Simulator(SimulatorInterface):
             self.prediction = True
         self.params = SimulatorParams(self.network, self.ing_nodes, self.eg_nodes, self.sfc_list, self.sf_list,
                                       self.config, self.metrics, prediction=self.prediction)
+        write_schedule = False
+        if 'write_schedule' in self.config and self.config['write_schedule']:
+            write_schedule = True
+        # Create CSV writer
+        self.writer = ResultWriter(self.test_mode, self.test_dir, write_schedule)
         self.episode = 0
 
     def __del__(self):


### PR DESCRIPTION
Added configurable schedule recording. It is off by default. 

User can turn it on again by adding `write_schedule: True` to the simulator config file. 