### PR TITLE
Separate MMP state calculation per node

### DIFF
--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -24,8 +24,10 @@ write_schedule: True
 # States (two state markov arrival)
 # Optional param: states: True | False 
 use_states: False
+# Required: init_state
 init_state: state_1
-
+# Optional: Apply random states as init. Still requires init_state to be defined.
+rand_init_state: True 
 states:
   state_1:
     inter_arr_mean: 10.0

--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -24,9 +24,9 @@ write_schedule: True
 # States (two state markov arrival)
 # Optional param: states: True | False 
 use_states: False
-# Required: init_state
+# Set the init state for nodes
 init_state: state_1
-# Optional: Apply random states as init. Still requires init_state to be defined.
+# Optional: Apply random states as init. Oerrides the state defined in init_state. 
 rand_init_state: True 
 states:
   state_1:

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -29,7 +29,7 @@ class SimulatorParams:
             self.use_trace = True
 
         self.prediction = prediction  # bool
-        self.predicted_inter_arr_mean = {node_id: config['inter_arrival_mean'] for node_id in self.network.nodes}
+        self.predicted_inter_arr_mean = {node_id[0]: config['inter_arrival_mean'] for node_id in self.ing_nodes}
 
         if schedule is None:
             schedule = {}
@@ -81,14 +81,14 @@ class SimulatorParams:
             self.states = config['states']
             if self.in_init_state:
                 # Create the inter_arr_mean dict
-                self.inter_arr_mean = {node_id: 0 for node_id in self.network.nodes}
+                self.inter_arr_mean = {node_id[0]: 0 for node_id in self.ing_nodes}
                 # If rand_init_state is activated, randomly select a state for each node
                 if 'rand_init_state' in config and config['rand_init_state']:
-                    self.current_states = {node_id: np.random.choice(
-                        list(self.states.keys())) for node_id in self.network.nodes}
+                    self.current_states = {node_id[0]: np.random.choice(
+                        list(self.states.keys())) for node_id in self.network.ing_nodes}
                 else:
                     # Initialize the state of all nodes with the init_state
-                    self.current_states = {node_id: self.init_state for node_id in self.network.nodes}
+                    self.current_states = {node_id[0]: self.init_state for node_id in self.ing_nodes}
             self.update_inter_arr_mean()
         else:
             inter_arr_mean = config['inter_arrival_mean']
@@ -119,9 +119,9 @@ class SimulatorParams:
         Change or keep the MMP state for each of the network's node
         State change decision made based on the switch probability defined with states definition in config.
         """
-        for node_id in self.network.nodes:
+        for node_id in self.ing_nodes:
             switch = [False, True]
-            current_state = self.current_states[node_id]
+            current_state = self.current_states[node_id[0]]
             change_prob = self.states[current_state]['switch_p']
             remain_prob = 1 - change_prob
             switch_decision = np.random.choice(switch, p=[remain_prob, change_prob])
@@ -131,7 +131,7 @@ class SimulatorParams:
                     current_state = state_names[1]
                 else:
                     current_state = state_names[0]
-                self.current_states[node_id] = current_state
+                self.current_states[node_id[0]] = current_state
         self.update_inter_arr_mean()
 
     def update_inter_arr_mean(self):
@@ -142,10 +142,10 @@ class SimulatorParams:
 
     def update_single_inter_arr_mean(self, new_mean):
         """Apply a single inter_arr_mean to all nodes"""
-        self.inter_arr_mean = {node_id: new_mean for node_id in self.network.nodes}
+        self.inter_arr_mean = {node_id[0]: new_mean for node_id in self.ing_nodes}
 
     def update_single_predicted_inter_arr_mean(self, new_mean):
-        self.predicted_inter_arr_mean = {node_id: new_mean for node_id in self.network.nodes}
+        self.predicted_inter_arr_mean = {node_id[0]: new_mean for node_id in self.ing_nodes}
 
     def reset_flow_lists(self):
         """Reset and re-init flow data lists and index. Called at the beginning of each new episode."""

--- a/src/coordsim/simulation/simulatorparams.py
+++ b/src/coordsim/simulation/simulatorparams.py
@@ -82,11 +82,13 @@ class SimulatorParams:
             if self.in_init_state:
                 # Create the inter_arr_mean dict
                 self.inter_arr_mean = {node_id: 0 for node_id in self.network.nodes}
-                # Initialize the state of all nodes with the init_state
-                self.current_states = {node_id: self.init_state for node_id in self.network.nodes}
-                # If rand_init_state is activated, update states now to generate random states for each node
+                # If rand_init_state is activated, randomly select a state for each node
                 if 'rand_init_state' in config and config['rand_init_state']:
-                    self.update_state(apply=False)
+                    self.current_states = {node_id: np.random.choice(
+                        list(self.states.keys())) for node_id in self.network.nodes}
+                else:
+                    # Initialize the state of all nodes with the init_state
+                    self.current_states = {node_id: self.init_state for node_id in self.network.nodes}
             self.update_inter_arr_mean()
         else:
             inter_arr_mean = config['inter_arrival_mean']
@@ -112,12 +114,10 @@ class SimulatorParams:
         params_str += f"deterministic_size: {self.deterministic_size}\n"
         return params_str
 
-    def update_state(self, apply=True):
+    def update_state(self):
         """
         Change or keep the MMP state for each of the network's node
         State change decision made based on the switch probability defined with states definition in config.
-
-        :param bool apply: Apply state changes to inter_arr_means. False means update states without applying changes.
         """
         for node_id in self.network.nodes:
             switch = [False, True]
@@ -132,8 +132,7 @@ class SimulatorParams:
                 else:
                     current_state = state_names[0]
                 self.current_states[node_id] = current_state
-        if apply:
-            self.update_inter_arr_mean()
+        self.update_inter_arr_mean()
 
     def update_inter_arr_mean(self):
         """Update inter arrival mean for each node based on """


### PR DESCRIPTION
Closes #128 
Two main additions:
- MMP state of each node is now calculated separately. Network nodes no longer share the same state.
- Nodes are initialized with the `init_state` in the simulator config file. We can now choose whether to do a state update after the initialization to possibly randomize the states at the start of the simulator. This can be done with setting `rand_init_state`. 


Possible optimizations: 
- Replace setting state and inter_arr_mean for all network nodes, and just set them for ingress nodes. (Not much performance benefit, just smaller memory footprint). 
  - If done, must check whether it affects runs with traces. This is why I haven't done it in this PR. 
