### PR TITLE
Record flow statistics per run

### DIFF
--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -57,6 +57,8 @@ class Metrics:
     def reset_run_metrics(self):
         """Set/Reset metrics belonging to one run"""
         self.metrics['run_dropped_flows_per_node'] = {v: 0 for v in self.network.nodes.keys()}
+        # Record total dropped flows per run
+        self.metrics['run_dropped_flows'] = 0
 
         self.metrics['run_end2end_delay'] = 0
         self.metrics['run_avg_end2end_delay'] = 0.0
@@ -132,6 +134,7 @@ class Metrics:
         self.metrics['total_active_flows'] -= 1
         self.metrics['dropped_flows_locs'][flow.current_node_id][flow.current_sf] += 1
         self.metrics['run_dropped_flows_per_node'][flow.current_node_id] += 1
+        self.metrics['run_dropped_flows'] += 1
         assert self.metrics['total_active_flows'] >= 0, "Cannot have negative active flows"
 
     def add_processing_delay(self, delay):

--- a/src/coordsim/writer/writer.py
+++ b/src/coordsim/writer/writer.py
@@ -127,7 +127,8 @@ class ResultWriter():
                 resource_output_row = [episode, time, node_id, node_cap, used_resources]
                 resource_output.append(resource_output_row)
 
-            run_flows_output = [episode, time, metrics['run_processed_flows'], metrics['run_dropped_flows'], metrics['run_generated_flows']]
+            run_flows_output = [episode, time, metrics['run_processed_flows'], metrics['run_dropped_flows'],
+                                metrics['run_generated_flows']]
             self.run_flows_writer.writerow(run_flows_output)
             self.metrics_writer.writerow(metrics_output)
             self.resources_writer.writerows(resource_output)

--- a/src/coordsim/writer/writer.py
+++ b/src/coordsim/writer/writer.py
@@ -27,6 +27,7 @@ class ResultWriter():
             self.metrics_file_name = f"{test_dir}/metrics.csv"
             self.dropped_flows_file_name = f"{test_dir}/dropped_flows.yaml"
             self.rl_state_file_name = f"{test_dir}/rl_state.csv"
+            self.run_flows_file_name = f"{test_dir}/run_flows.csv"
 
             # Create the results directory if not exists
             os.makedirs(os.path.dirname(self.placement_file_name), exist_ok=True)
@@ -35,6 +36,7 @@ class ResultWriter():
             self.resources_stream = open(self.resources_file_name, 'a+', newline='')
             self.metrics_stream = open(self.metrics_file_name, 'a+', newline='')
             self.rl_state_stream = open(self.rl_state_file_name, 'a+', newline='')
+            self.run_flows_stream = open(self.run_flows_file_name, 'a+', newline='')
 
             if self.write_schedule:
                 self.scheduleing_stream = open(self.scheduling_file_name, 'a+', newline='')
@@ -44,6 +46,7 @@ class ResultWriter():
             self.resources_writer = csv.writer(self.resources_stream)
             self.metrics_writer = csv.writer(self.metrics_stream)
             self.rl_state_writer = csv.writer(self.rl_state_stream)
+            self.run_flows_writer = csv.writer(self.run_flows_stream)
 
             # Write the headers to the files
             self.create_csv_headers()
@@ -57,6 +60,7 @@ class ResultWriter():
             self.resources_stream.close()
             self.metrics_stream.close()
             self.rl_state_stream.close()
+            self.run_flows_stream.close()
 
     def create_csv_headers(self):
         """
@@ -71,11 +75,13 @@ class ResultWriter():
         resources_output_header = ['episode', 'time', 'node', 'node_capacity', 'used_resources']
         metrics_output_header = ['episode', 'time', 'total_flows', 'successful_flows', 'dropped_flows',
                                  'in_network_flows', 'avg_end2end_delay']
+        run_flows_output_header = ['episode', 'time', 'successful_flows', 'dropped_flows', 'total_flows']
 
         # Write headers to CSV files
         self.placement_writer.writerow(placement_output_header)
         self.resources_writer.writerow(resources_output_header)
         self.metrics_writer.writerow(metrics_output_header)
+        self.run_flows_writer.writerow(run_flows_output_header)
 
     def write_action_result(self, episode, time, action: SimulatorAction):
         """
@@ -102,7 +108,7 @@ class ResultWriter():
 
             self.placement_writer.writerows(placement_output)
 
-    def write_state_results(self, episode, time, state: SimulatorState):
+    def write_state_results(self, episode, time, state: SimulatorState, metrics):
         """
         Write node resource consumption to CSV file
         """
@@ -121,6 +127,8 @@ class ResultWriter():
                 resource_output_row = [episode, time, node_id, node_cap, used_resources]
                 resource_output.append(resource_output_row)
 
+            run_flows_output = [episode, time, metrics['run_processed_flows'], metrics['run_dropped_flows'], metrics['run_generated_flows']]
+            self.run_flows_writer.writerow(run_flows_output)
             self.metrics_writer.writerow(metrics_output)
             self.resources_writer.writerows(resource_output)
 

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -191,7 +191,7 @@ class Simulator(SimulatorInterface):
         # Create a new SimulatorState object to pass to the RL Agent
         simulator_state = SimulatorState(self.network_dict, self.simulator.params.sf_placement, self.sfc_list,
                                          self.sf_list, self.traffic, self.network_stats)
-        self.writer.write_state_results(self.episode, self.env.now, simulator_state, stats)
+        self.writer.write_state_results(self.episode, self.env.now, simulator_state, self.params.metrics.get_metrics())
         logger.debug(f"t={self.env.now}: {simulator_state}")
 
         return simulator_state

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -191,7 +191,7 @@ class Simulator(SimulatorInterface):
         # Create a new SimulatorState object to pass to the RL Agent
         simulator_state = SimulatorState(self.network_dict, self.simulator.params.sf_placement, self.sfc_list,
                                          self.sf_list, self.traffic, self.network_stats)
-        self.writer.write_state_results(self.episode, self.env.now, simulator_state)
+        self.writer.write_state_results(self.episode, self.env.now, simulator_state, stats)
         logger.debug(f"t={self.env.now}: {simulator_state}")
 
         return simulator_state


### PR DESCRIPTION
Closes #160 

I added flow metrics recording per run. The simulator is now creating a new csv file called `run_flows.csv`.  The file has the following header:
```
episode,time,successful_flows,dropped_flows,total_flows
```
The metrics recorded are now run specific and do not increment with more runs like the `metrics.csv` file. 