### PR TITLE
Use nx v2.4 instead of latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 requirements = [
     'simpy>=4',
-    'networkx',
+    'networkx==2.4',
     'geopy',
     'pyyaml>=5.1',
     'numpy==1.16.4',


### PR DESCRIPTION
The latest update of networkx breaks when reading graphml files with datatype `long`.
A fix was merged in their repo (https://github.com/networkx/networkx/pull/4189) but isn't pushed to PyPI as of now. 

For now, let's stick to using v2.4 until the fix is pushed to PyPI. 