### PR TITLE
Schedules: Use weighted RR to select next node

### DIFF
--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -84,7 +84,8 @@ class Metrics:
 
         # per-run flow counter for all destination nodes for all src nodes, sfcs, sfs in the scheduling table
         # only relevant for weighted round robin scheduling
-        self.metrics['run_flow_counts'] = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int))))
+        self.metrics['run_flow_counts'] = \
+            defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int))))
 
     def calc_max_node_usage(self, node_id, current_usage):
         """

--- a/src/coordsim/metrics/metrics.py
+++ b/src/coordsim/metrics/metrics.py
@@ -82,6 +82,10 @@ class Metrics:
         # total processed traffic (aggregated data rate) per node per SF within one run
         self.metrics['run_total_processed_traffic'] = defaultdict(lambda: defaultdict(float))
 
+        # per-run flow counter for all destination nodes for all src nodes, sfcs, sfs in the scheduling table
+        # only relevant for weighted round robin scheduling
+        self.metrics['run_flow_counts'] = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(int))))
+
     def calc_max_node_usage(self, node_id, current_usage):
         """
         Calculate the run's max node usage

--- a/src/coordsim/network/dummy_data.py
+++ b/src/coordsim/network/dummy_data.py
@@ -181,9 +181,9 @@ triangle_schedule = {
     'pop0': {
         'sfc_1': {
             'a': {
-                'pop0': 1,
-                'pop1': 0,
-                'pop2': 0
+                'pop0': 0.6,
+                'pop1': 0.3,
+                'pop2': 0.1
             },
             'b': {
                 'pop0': 0,


### PR DESCRIPTION
Rather than selecting the next node randomly according to the scheduling probabilities, use a modified version of weighted RR.
It still leads to the same ratio of flows being send to the destinations as specified in the schedule. But it avoids sending consecutive flows to the same destination as far as possible.
Such consecutive flows easily get dropped if the destination's resources are already fully utilized by the previous flow since we don't queue flows.