### PR TITLE
Set per-flow generator as default and set list generator as optional

### DIFF
--- a/src/coordsim/flow_generators/base_generator.py
+++ b/src/coordsim/flow_generators/base_generator.py
@@ -13,7 +13,12 @@ class BaseFlowGenerator:
     All flow generator classes must inherit this class
     """
     def __init__(self, env: Environment, params: SimulatorParams):
-        pass
+        raise NotImplementedError
 
     def generate_flow(self, flow_id, node_id) -> Tuple[float, Flow]:
-        pass
+        """ Generate flow
+        Returns:
+            - float: inter arrival time to wait for next flow arrival
+            - Flow: flow object containing all required parameters set
+        """
+        raise NotImplementedError

--- a/src/coordsim/flow_generators/list_generator.py
+++ b/src/coordsim/flow_generators/list_generator.py
@@ -7,7 +7,7 @@ from coordsim.flow_generators import BaseFlowGenerator
 log = logging.getLogger(__name__)
 
 
-class DefaultFlowGenerator(BaseFlowGenerator):
+class ListFlowGenerator(BaseFlowGenerator):
     """
     This is the default generator class. It generates and inits flows from simulatorparams
     """
@@ -17,14 +17,7 @@ class DefaultFlowGenerator(BaseFlowGenerator):
 
     def generate_flow(self, flow_id, node_id) -> Tuple[float, Flow]:
         """ Generate a flow for a given node_id """
-        if self.params.deterministic_arrival:
-            inter_arr_time = self.params.inter_arr_mean[node_id]
-        else:
-            # Poisson arrival -> exponential distributed inter-arrival time
-            inter_arr_time = random.expovariate(lambd=1.0 / self.params.inter_arr_mean[node_id])
-        flow_dr, flow_size = self.get_flow_dr_size()
-        # if flow_dr <= 0.00 or flow_size <= 0.00:
-        #     continue
+        inter_arr_time, flow_dr, flow_size = self.params.get_next_flow_data(node_id)
 
         # Assign a random SFC to the flow
         flow_sfc = np.random.choice([sfc for sfc in self.params.sfc_list.keys()])
@@ -43,18 +36,3 @@ class DefaultFlowGenerator(BaseFlowGenerator):
         self.params.metrics.generated_flow(flow, node_id)
 
         return inter_arr_time, flow
-
-    def get_flow_dr_size(self):
-        """ Generate data rate and size values for a flow """
-        # set normally distributed flow data rate
-        flow_dr = np.random.normal(self.params.flow_dr_mean, self.params.flow_dr_stdev)
-        if self.params.deterministic_size:
-            flow_size = self.params.flow_size_shape
-        else:
-            # heavy-tail flow size
-            flow_size = np.random.pareto(self.params.flow_size_shape) + 1
-        # Recursive call if flow size or dr < 0 until a value is obtained
-        while flow_dr < 0.00 or flow_size < 0.00:
-            flow_dr, flow_size = self.get_flow_dr_size()
-
-        return flow_dr, flow_size


### PR DESCRIPTION
Using the list flow generator module is now optional and can be set in the sim config file. The default is a per-flow generator as it used to be before.