### PR TITLE
Random flow scheduling instead of RR

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = [
     'networkx==2.4',
     'geopy',
     'pyyaml>=5.1',
-    'numpy==1.16.4',
+    'numpy>=1.16.5',
     'common-utils',
     'cython',   # otherwise sklearn fails
     'sklearn',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ requirements = [
     'pyyaml>=5.1',
     'numpy==1.16.4',
     'common-utils',
+    'cython',   # otherwise sklearn fails
     'sklearn',
     'pandas',
     'tensorflow==1.14.0',

--- a/src/coordsim/decision_maker/default_decision_maker.py
+++ b/src/coordsim/decision_maker/default_decision_maker.py
@@ -39,6 +39,9 @@ class DefaultDecisionMaker(BaseDecisionMaker):
             dest_nodes = [sch_sf for sch_sf in local_schedule.keys()]
             dest_prob = [prob for name, prob in local_schedule.items()]
             try:
+                # TODO: test random weighted scheduling instead of RR-based scheduling below
+                return np.random.choice(dest_nodes, p=dest_prob)
+
                 # select next node based on weighted RR according to the scheduling weights/probabilities
                 # get current flow counts per possible destination node
                 flow_counts = self.params.metrics.metrics['run_flow_counts'][flow.current_node_id][flow.sfc][sf]


### PR DESCRIPTION
When flows are scheduled to a new node for processing, they are scheduled randomly according to the given scheduling probabilities (as in CNSM paper).

Before, they were scheduled using weighted round robin.

