### PR TITLE
Fix metrics writing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements = [
     'networkx==2.4',
     'geopy',
     'pyyaml>=5.1',
-    'numpy==1.16.4',
+    'numpy>=1.16.5',
     'common-utils',
     'cython',   # otherwise sklearn fails
     'sklearn',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ requirements = [
     'pyyaml>=5.1',
     'numpy==1.16.4',
     'common-utils',
+    'cython',   # otherwise sklearn fails
     'sklearn',
     'pandas',
     'tensorflow==1.14.0',

--- a/src/coordsim/decision_maker/default_decision_maker.py
+++ b/src/coordsim/decision_maker/default_decision_maker.py
@@ -39,9 +39,6 @@ class DefaultDecisionMaker(BaseDecisionMaker):
             dest_nodes = [sch_sf for sch_sf in local_schedule.keys()]
             dest_prob = [prob for name, prob in local_schedule.items()]
             try:
-                # TODO: test random weighted scheduling instead of RR-based scheduling below
-                return np.random.choice(dest_nodes, p=dest_prob)
-
                 # select next node based on weighted RR according to the scheduling weights/probabilities
                 # get current flow counts per possible destination node
                 flow_counts = self.params.metrics.metrics['run_flow_counts'][flow.current_node_id][flow.sfc][sf]

--- a/src/coordsim/decision_maker/default_decision_maker.py
+++ b/src/coordsim/decision_maker/default_decision_maker.py
@@ -39,6 +39,9 @@ class DefaultDecisionMaker(BaseDecisionMaker):
             dest_nodes = [sch_sf for sch_sf in local_schedule.keys()]
             dest_prob = [prob for name, prob in local_schedule.items()]
             try:
+                # TODO: test random weighted scheduling instead of RR-based scheduling below
+                return np.random.choice(dest_nodes, p=dest_prob)
+
                 # select next node based on weighted RR according to the scheduling weights/probabilities
                 # get current flow counts per possible destination node
                 flow_counts = self.params.metrics.metrics['run_flow_counts'][flow.current_node_id][flow.sfc][sf]

--- a/src/coordsim/writer/writer.py
+++ b/src/coordsim/writer/writer.py
@@ -218,6 +218,8 @@ class ResultWriter():
                     placement_output.append(placement_output_row)
             self.placement_writer.writerows(placement_output)
 
+        # reset metrics for run
+        self.params.metrics.reset_run_metrics()
         # Wait a timeout then write the states
         yield self.env.timeout(self.params.run_duration)
         yield self.env.process(self.write_network_state())

--- a/src/siminterface/simulator.py
+++ b/src/siminterface/simulator.py
@@ -185,8 +185,8 @@ class Simulator(SimulatorInterface):
         # Set it in the params of the instantiated simulator object.
         # self.simulator.params.schedule = actions.scheduling
 
-        # reset metrics for steps
-        self.params.metrics.reset_run_metrics()
+        # reset metrics for steps; now done in result writer
+        # self.params.metrics.reset_run_metrics()
 
         # Run the simulation again with the new params for the set duration.
         # Due to SimPy restraints, we multiply the duration by the run times because SimPy does not reset when run()


### PR DESCRIPTION
Write run metrics before resetting them inside the writer (not inside apply).

Important for `node_metrics.csv` and `flow_metrics.csv`. `metrics.csv` already worked before.