### PR TITLE
Fixed bug when specifying trace_path in simulator config

### DIFF
--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -17,7 +17,7 @@ ttl_choices: [50]
 
 # Optional: Trace file trace relative to the CWD.
 # Until values start in the trace file, the defaults from this file are used
-# trace_path: params/traces/default_trace.csv
+trace_path: params/traces/default_trace.csv
 
 # future_traffic: True
 # lstm_prediction: True

--- a/params/config/sim_config.yaml
+++ b/params/config/sim_config.yaml
@@ -17,7 +17,7 @@ ttl_choices: [50]
 
 # Optional: Trace file trace relative to the CWD.
 # Until values start in the trace file, the defaults from this file are used
-trace_path: params/traces/default_trace.csv
+# trace_path: params/traces/default_trace.csv
 
 # future_traffic: True
 # lstm_prediction: True

--- a/src/coordsim/main.py
+++ b/src/coordsim/main.py
@@ -48,13 +48,13 @@ def main():
                              sf_placement=sf_placement, schedule=schedule)
     log.info(params)
 
+    # Create a FlowSimulator object, pass the SimPy environment and params objects
+    simulator = FlowSimulator(env, params)
     if 'trace_path' in config:
         trace_path = os.path.join(os.getcwd(), config['trace_path'])
         trace = reader.get_trace(trace_path)
-        TraceProcessor(params, env, trace)
+        TraceProcessor(params, env, trace, simulator)
         log.info("Using trace " + config['trace_path'])
-    # Create a FlowSimulator object, pass the SimPy environment and params objects
-    simulator = FlowSimulator(env, params)
 
     # Start the simulation
     simulator.start()


### PR DESCRIPTION
I found and fixed a small bug:

When uncommenting line 20 in [`params/config/sim_config.yaml`](https://github.com/RealVNF/coord-sim/blob/1566fc1f8500377954c2038ba8f8c2b6c83c92ff/params/config/sim_config.yaml), an error occurred because in [`src/coord-sim/main.py`](https://github.com/RealVNF/coord-sim/blob/1566fc1f8500377954c2038ba8f8c2b6c83c92ff/src/coordsim/main.py), when calling the `TraceProcessor`, it was requiring the `FlowSimulator` as an argument.

The `FlowSimulator` was defined below this line, therefore I moved its definition above the if-statement and passed the object to the `traceProcessor`:

Before:
```
if 'trace_path' in config:
    trace_path = os.path.join(os.getcwd(), config['trace_path'])
    trace = reader.get_trace(trace_path)
    TraceProcessor(params, env, trace)
    log.info("Using trace " + config['trace_path'])
# Create a FlowSimulator object, pass the SimPy environment and params objects
simulator = FlowSimulator(env, params)
```

After:
```
# Create a FlowSimulator object, pass the SimPy environment and params objects
simulator = FlowSimulator(env, params)
if 'trace_path' in config:
    trace_path = os.path.join(os.getcwd(), config['trace_path'])
    trace = reader.get_trace(trace_path)
    TraceProcessor(params, env, trace, simulator)
    log.info("Using trace " + config['trace_path'])
```